### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a report of a bug you've encountered to help us improve
+title: 'BUG: '
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug/error**
+> What happened?
+
+A clear and concise description of what the bug is
+
+**To Reproduce**
+> How did you get to that error/ bug?
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+> What did you expect to happen?
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -13,8 +13,8 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've come across**
+A clear and concise description of any alternative solutions or features you've come across.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a new feature or idea for bible.com
+title: Feature request / General idea
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/growth-idea.md
+++ b/.github/ISSUE_TEMPLATE/growth-idea.md
@@ -1,0 +1,20 @@
+---
+name: Growth idea
+about: Suggest an idea for growth (SEO, Organic Traffic, the like) for bible.com
+title: 'Growth idea: '
+labels: growth
+assignees: NdagiStanley
+
+---
+
+**Is your growth idea related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. Bible.com is inaccessible to [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives that can be considered**
+A clear and concise description of any alternative solutions or features you've considered viable.
+
+**Additional context**
+Add any other context or screenshots (from elsewhere or other parts of the web app) about the idea here.

--- a/.github/ISSUE_TEMPLATE/growth-idea.md
+++ b/.github/ISSUE_TEMPLATE/growth-idea.md
@@ -10,7 +10,7 @@ assignees: ''
 **Describe the idea you have in mind**
 A clear and concise description of what you would like to happen.
 
-**Defence for the idea**
+**Defense for the idea**
 - How the idea will improve growth?
 - What area of growth it will improve?
 - What do you think is estimated level of effort to implement this?

--- a/.github/ISSUE_TEMPLATE/growth-idea.md
+++ b/.github/ISSUE_TEMPLATE/growth-idea.md
@@ -3,7 +3,7 @@ name: Growth idea
 about: Suggest an idea for growth (SEO, Organic Traffic, the like) for bible.com
 title: 'Growth idea: '
 labels: growth
-assignees: NdagiStanley
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/growth-idea.md
+++ b/.github/ISSUE_TEMPLATE/growth-idea.md
@@ -1,20 +1,19 @@
 ---
 name: Growth idea
-about: Suggest an idea for growth (SEO, Organic Traffic, the like) for bible.com
+about: Suggest an idea for driving growth (SEO, Organic Traffic, the like) for bible.com
 title: 'Growth idea: '
 labels: growth
 assignees: ''
 
 ---
 
-**Is your growth idea related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. Bible.com is inaccessible to [...]
+**Describe the idea you have in mind**
+A clear and concise description of what you would like to happen.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives that can be considered**
-A clear and concise description of any alternative solutions or features you've considered viable.
+**Defence for the idea**
+- How the idea will improve growth?
+- What area of growth it will improve?
+- What do you think is estimated level of effort to implement this?
 
 **Additional context**
-Add any other context or screenshots (from elsewhere or other parts of the web app) about the idea here.
+Add any other context like screenshots, white papers etc. (from elsewhere or other parts of the web app) about the idea here.


### PR DESCRIPTION
#### What does this PR do?
Adds 3 issue templates:
- bug
- feature/ general idea
- growth idea
#### How should this be manually tested?
When creating an issue you'd see a list of the template issues to pick from.

The selected issue will have the corresponding tag tied to it.